### PR TITLE
Add installation test

### DIFF
--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -32,9 +32,7 @@ jobs:
           artifact_type: 'container'
           artifact_path: 'alpine:latest'
 
-      - name: simulate failure
-        run: exit 1
-
+      # only run if the previous step failed
       - name: Notify maintainers of installation failure
         if: ${{ failure() }}
         run: echo "this feature is not implemented"


### PR DESCRIPTION
## Description

This PR adds an integration test to verify that customers can successfully install this GitHub Actions plugin.

This PR does not include alarm integration; that will follow in a separate PR after we setup the alarming infrastructure.


## Related Issues

- N/A


*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*


