### PR TITLE
Updated workflows and license text

### DIFF
--- a/.github/workflows/build_scan_container.yml
+++ b/.github/workflows/build_scan_container.yml
@@ -47,12 +47,12 @@ jobs:
           # TODO: use an IAM role
 
       - name: Scan built image with Inspector
-        uses: aws/amazon-inspector-github-actions-plugin@main 
-        # TODO: bump action to v1 on release
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
         id: inspector
         with:
           artifact_type: 'container'
           artifact_path: 'ubuntu:14.04'
+          display_vulnerability_findings: "enabled"
           output_sbom_path: 'sbom.json'
           output_inspector_scan_path: 'inspector_scan.json'
           output_inspector_scan_path_csv: 'inspector_scan.csv'
@@ -64,7 +64,7 @@ jobs:
 
       - name: Demonstrate SBOM Output (JSON)
         run: cat ${{ steps.inspector.outputs.artifact_sbom }}
- 
+
       - name: Demonstrate Inspector Scan Output (JSON)
         run: cat ${{ steps.inspector.outputs.inspector_scan_results }}
 

--- a/.github/workflows/test_archive.yml
+++ b/.github/workflows/test_archive.yml
@@ -32,11 +32,12 @@ jobs:
 
       - name: Test archive scan
         id: inspector
-        uses: aws/amazon-inspector-github-actions-plugin@main 
-        # TODO: update this to point to public v1.0.0 release
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
         with:
           artifact_type: 'archive'
-          artifact_path: 'entrypoint/tests/test_data/artifacts/archives/testData.zip' 
+          artifact_path: 'entrypoint/tests/test_data/artifacts/archives/testData.zip'
+          display_vulnerability_findings: "enabled"
+
       - name: Display scan results
         run: cat ${{ steps.inspector.outputs.inspector_scan_results }}
 
@@ -44,7 +45,7 @@ jobs:
         run: python3 validator/validate_inspector_scan.py --file ${{ steps.inspector.outputs.inspector_scan_results }}
 
       # only run if the previous step failed
-      - name: Notify maintainers of validation failure 
+      - name: Notify maintainers of validation failure
         if: ${{ failure() }}
         run: echo "this feature is not implemented"
         # TODO: add steps to send notification to a Lambda to cut a ticket on job failure

--- a/.github/workflows/test_binary.yml
+++ b/.github/workflows/test_binary.yml
@@ -32,11 +32,12 @@ jobs:
 
       - name: Test binary scan
         id: inspector
-        uses: aws/amazon-inspector-github-actions-plugin@main 
-        # TODO: update this to point to public v1.0.0 release
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
         with:
           artifact_type: 'binary'
-          artifact_path: 'entrypoint/tests/test_data/artifacts/binaries/inspector-sbomgen' 
+          artifact_path: 'entrypoint/tests/test_data/artifacts/binaries/inspector-sbomgen'
+          display_vulnerability_findings: "enabled"
+
       - name: Display scan results
         run: cat ${{ steps.inspector.outputs.inspector_scan_results }}
 
@@ -44,7 +45,7 @@ jobs:
         run: python3 validator/validate_inspector_scan.py --file ${{ steps.inspector.outputs.inspector_scan_results }}
 
       # only run if the previous step failed
-      - name: Notify maintainers of validation failure 
+      - name: Notify maintainers of validation failure
         if: ${{ failure() }}
         run: echo "this feature is not implemented"
         # TODO: add steps to send notification to a Lambda to cut a ticket on job failure

--- a/.github/workflows/test_containers.yml
+++ b/.github/workflows/test_containers.yml
@@ -32,11 +32,11 @@ jobs:
 
       - name: Test container scan
         id: inspector
-        uses: aws/amazon-inspector-github-actions-plugin@main 
-        # TODO: update this to point to public v1.0.0 release
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
         with:
           artifact_type: 'container'
           artifact_path: 'ubuntu:14.04'
+          display_vulnerability_findings: "enabled"
 
       - name: Display scan results
         run: cat ${{ steps.inspector.outputs.inspector_scan_results }}
@@ -45,7 +45,7 @@ jobs:
         run: python3 validator/validate_inspector_scan.py --file ${{ steps.inspector.outputs.inspector_scan_results }}
 
       # only run if the previous step failed
-      - name: Notify maintainers of validation failure 
+      - name: Notify maintainers of validation failure
         if: ${{ failure() }}
         run: echo "this feature is not implemented"
         # TODO: add steps to send notification to a Lambda to cut a ticket on job failure

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -27,10 +27,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Test Amazon Inspector GitHub Actions plugin
-        uses: aws/amazon-inspector-github-actions-plugin@main 
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
         with:
           artifact_type: 'container'
           artifact_path: 'alpine:latest'
+          display_vulnerability_findings: "enabled"
 
       # only run if the previous step failed
       - name: Notify maintainers of installation failure

--- a/.github/workflows/test_repository.yml
+++ b/.github/workflows/test_repository.yml
@@ -31,11 +31,11 @@ jobs:
 
       - name: Test repository scan
         id: inspector
-        uses: aws/amazon-inspector-github-actions-plugin@main 
-        # TODO: update this to point to public v1.0.0 release
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
         with:
           artifact_type: 'repository'
-          artifact_path: './' 
+          artifact_path: './'
+          display_vulnerability_findings: "enabled"
 
       - name: Display scan results
         run: cat ${{ steps.inspector.outputs.inspector_scan_results }}
@@ -44,7 +44,7 @@ jobs:
         run: python3 validator/validate_inspector_scan.py --file ${{ steps.inspector.outputs.inspector_scan_results }}
 
       # only run if the previous step failed
-      - name: Notify maintainers of validation failure 
+      - name: Notify maintainers of validation failure
         if: ${{ failure() }}
         run: echo "this feature is not implemented"
         # TODO: add steps to send notification to a Lambda to cut a ticket on job failure

--- a/.github/workflows/test_vuln_thresholds.yml
+++ b/.github/workflows/test_vuln_thresholds.yml
@@ -29,11 +29,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Scan artifact with Inspector
-        uses: ./ # Uses an action in the root directory
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
         id: inspector
         with:
           artifact_type: 'archive'
           artifact_path: 'entrypoint/tests/test_data/artifacts/archives/testData.zip'
+          display_vulnerability_findings: "enabled"
           output_sbom_path: 'sbom.json'
           output_inspector_scan_path: 'inspector_scan.json'
           output_inspector_scan_path_csv: 'inspector_scan.csv'

--- a/README.md
+++ b/README.md
@@ -375,5 +375,6 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 
 ## License
 
-This project is licensed under the Apache-2.0 License.
+This project is licensed under the MIT license.
 
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved


### PR DESCRIPTION
This updates workflows to point to this repository (@main).

This will be changed to @v1 prior to launch.

This also replaces the license text from Apache 2 to MIT.