### PR TITLE
Update workflows to use IAM role auth

### DIFF
--- a/.github/workflows/build_scan_container.yml
+++ b/.github/workflows/build_scan_container.yml
@@ -44,7 +44,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # TODO: use an IAM role
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Scan built image with Inspector
         uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.0.0

--- a/.github/workflows/example_display_findings.yml
+++ b/.github/workflows/example_display_findings.yml
@@ -23,6 +23,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
 
       # modify this block to scan your intended artifact

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # TODO: use an IAM role
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Run unit tests
         run: make test

--- a/.github/workflows/test_archive.yml
+++ b/.github/workflows/test_archive.yml
@@ -28,7 +28,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # TODO: use an IAM role
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Test archive scan
         id: inspector

--- a/.github/workflows/test_binary.yml
+++ b/.github/workflows/test_binary.yml
@@ -28,7 +28,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # TODO: use an IAM role
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Test binary scan
         id: inspector

--- a/.github/workflows/test_containers.yml
+++ b/.github/workflows/test_containers.yml
@@ -28,7 +28,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # TODO: use an IAM role
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Test container scan
         id: inspector

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -22,9 +22,10 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-region: 'us-east-1'
+          aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Test Amazon Inspector GitHub Actions plugin
         uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main

--- a/.github/workflows/test_repository.yml
+++ b/.github/workflows/test_repository.yml
@@ -25,9 +25,9 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # TODO: use an IAM role
+          # aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          # aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Test repository scan
         id: inspector

--- a/.github/workflows/test_repository.yml
+++ b/.github/workflows/test_repository.yml
@@ -25,8 +25,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          # aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Test repository scan

--- a/.github/workflows/test_repository.yml
+++ b/.github/workflows/test_repository.yml
@@ -25,8 +25,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          # aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          # aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Test repository scan

--- a/.github/workflows/test_vuln_thresholds.yml
+++ b/.github/workflows/test_vuln_thresholds.yml
@@ -27,6 +27,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Scan artifact with Inspector
         uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main


### PR DESCRIPTION
## Description

Before this change, this project's workflows used AWS session and secret keys to authenticate to Inspector.

After this change, the project workflows use IAM roles for authentication, which adds security benefits:
- Roles provide temporary credentials that can be used to invoke Inspector, after which point, the credentials expire.

## Related Issues

N/A


*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*


