### PR TITLE
Fix action version number in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Perform the following steps to quickly add this action to your GitHub Actions pi
          # modify this block to scan your intended artifact
          - name: Inspector Scan
            id: inspector
-           uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
+           uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.0.0
            with:
              # change artifact_type to either 'repository', 'container', 'binary', or 'archive'.
              artifact_type: 'repository'
@@ -169,7 +169,7 @@ The below example shows how to enable action outputs in various locations and fo
 ```yaml
 - name: Scan container
   id: inspector
-  uses: aws/vulnerability-scan-github-action-for-amazon-inspector@v1
+  uses: aws/vulnerability-scan-github-action-for-amazon-inspector@v1.0.0
   with:
     artifact_type: 'container'
     artifact_path: 'ubuntu:14.04'
@@ -213,7 +213,7 @@ The example below shows how to set up vulnerability thresholds and fail the job 
 ```yaml
 - name: Invoke Amazon Inspector Scan
   id: inspector
-  uses: aws/vulnerability-scan-github-action-for-amazon-inspector@v1
+  uses: aws/vulnerability-scan-github-action-for-amazon-inspector@v1.0.0
   with:
     artifact_type: 'repository'
     artifact_path: './'
@@ -288,7 +288,7 @@ jobs:
           role-to-assume: "arn:aws:iam::<AWS_ACCOUNT_ID>:role/<IAM_ROLE_NAME>"
 
       - name: Scan built image with Inspector
-        uses: aws/amazon-inspector-github-actions-plugin@v1
+        uses: aws/amazon-inspector-github-actions-plugin@v1.0.0
         id: inspector
         with:
           artifact_type: 'container'


### PR DESCRIPTION
## Description

Before this change, this action's version numbers were listed as `v1` in the example README.

This version number does not work on GitHub Actions.

After this change, the examples are updated to `v1.0.0`.



## Related Issues

N/A


*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*


