### PR TITLE
Resolve v1.1.0 errors

### DIFF
--- a/.github/workflows/build_scan_container.yml
+++ b/.github/workflows/build_scan_container.yml
@@ -47,7 +47,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Scan built image with Inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@debugging_1.1.0_errors
         id: inspector
         with:
           artifact_type: 'container'

--- a/.github/workflows/example_display_findings.yml
+++ b/.github/workflows/example_display_findings.yml
@@ -29,7 +29,7 @@ jobs:
       # modify this block to scan your intended artifact
       - name: Inspector Scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@debugging_1.1.0_errors
         with:
           # change artifact_type to either 'repository', 'container', 'binary', or 'archive'.
           # this example scans a container image

--- a/.github/workflows/test_archive.yml
+++ b/.github/workflows/test_archive.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Test archive scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@debugging_1.1.0_errors
         with:
           artifact_type: 'archive'
           artifact_path: 'entrypoint/tests/test_data/artifacts/archives/testData.zip'

--- a/.github/workflows/test_binary.yml
+++ b/.github/workflows/test_binary.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Test binary scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@debugging_1.1.0_errors
         with:
           artifact_type: 'binary'
           artifact_path: 'entrypoint/tests/test_data/artifacts/binaries/inspector-sbomgen'

--- a/.github/workflows/test_containers.yml
+++ b/.github/workflows/test_containers.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Test container scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@debugging_1.1.0_errors
         with:
           artifact_type: 'container'
           artifact_path: 'ubuntu:14.04'

--- a/.github/workflows/test_dockerfile_vulns.yml
+++ b/.github/workflows/test_dockerfile_vulns.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Scan Dockerfiles
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@debugging_1.1.0_errors
         with:
           artifact_type: 'repository'
           artifact_path: './'

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -28,7 +28,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Test Amazon Inspector GitHub Actions plugin
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@debugging_1.1.0_errors
         with:
           artifact_type: 'container'
           artifact_path: 'alpine:latest'

--- a/.github/workflows/test_no_vulns.yml
+++ b/.github/workflows/test_no_vulns.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Test binary scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@debugging_1.1.0_errors
         with:
           artifact_type: 'binary'
           artifact_path: 'entrypoint/tests/test_data/artifacts/binaries/test_go_binary'

--- a/.github/workflows/test_repository.yml
+++ b/.github/workflows/test_repository.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Test repository scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@debugging_1.1.0_errors
         with:
           artifact_type: 'repository'
           artifact_path: './'

--- a/.github/workflows/test_vuln_thresholds.yml
+++ b/.github/workflows/test_vuln_thresholds.yml
@@ -30,7 +30,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Scan artifact with Inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@debugging_1.1.0_errors
         id: inspector
         with:
           artifact_type: 'archive'

--- a/entrypoint/entrypoint/orchestrator.py
+++ b/entrypoint/entrypoint/orchestrator.py
@@ -57,11 +57,10 @@ def post_dockerfile_step_summary(args, total_vulns):
 
         dockerfile_markdown = ""
         try:
-            f = open(args.out_dockerfile_scan_md, "r")
-            dockerfile_markdown = f.read()
-            f.close()
+            with open(args.out_dockerfile_scan_md, "r") as f:
+                dockerfile_markdown = f.read()
         except Exception as e:
-            logging.info(e)
+            logging.error(e)
             return
 
         if not dockerfile_markdown:

--- a/entrypoint/entrypoint/orchestrator.py
+++ b/entrypoint/entrypoint/orchestrator.py
@@ -60,7 +60,7 @@ def post_dockerfile_step_summary(args, total_vulns):
             with open(args.out_dockerfile_scan_md, "r") as f:
                 dockerfile_markdown = f.read()
         except Exception as e:
-            logging.error(e)
+            logging.debug(e) # can be spammy, so set as debug log
             return
 
         if not dockerfile_markdown:

--- a/entrypoint/entrypoint/orchestrator.py
+++ b/entrypoint/entrypoint/orchestrator.py
@@ -57,8 +57,9 @@ def post_dockerfile_step_summary(args, total_vulns):
 
         dockerfile_markdown = ""
         try:
-            with open(args.out_dockerfile_scan_md, "r") as f:
-                dockerfile_markdown = f.read()
+            f = open(args.out_dockerfile_scan_md, "r")
+            dockerfile_markdown = f.read()
+            f.close()
         except Exception as e:
             logging.info(e)
             return


### PR DESCRIPTION
This action, v1.1.0, was throwing an unhanded exception in when there were zero Dockerfile findings.
Because there were zero Dockerfile findings, the Dockerfile markdown report was not written.
A later function would attempt to read a non-existent Dockerfile in this scenario, resulting in a fatal exception.

The code now gracefully handles this condition.