### PR TITLE
Fix: readme points to action that does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ jobs:
           role-to-assume: "arn:aws:iam::<AWS_ACCOUNT_ID>:role/<IAM_ROLE_NAME>"
 
       - name: Scan built image with Inspector
-        uses: aws/amazon-inspector-github-actions-plugin@v1.0.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.0.0
         id: inspector
         with:
           artifact_type: 'container'


### PR DESCRIPTION
## Description

It seems that one of the examples in the README points to an action that does not exist.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*