### PR TITLE
Show vulnerability summary on zero vulns

### DIFF
--- a/.github/workflows/test_no_vulns.yml
+++ b/.github/workflows/test_no_vulns.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Test binary scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@show_summary_on_zero_vulns
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@1.1.0
         with:
           artifact_type: 'binary'
           artifact_path: 'entrypoint/tests/test_data/artifacts/binaries/test_go_binary'

--- a/.github/workflows/test_no_vulns.yml
+++ b/.github/workflows/test_no_vulns.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Test binary scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@1.1.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.0
         with:
           artifact_type: 'binary'
           artifact_path: 'entrypoint/tests/test_data/artifacts/binaries/test_go_binary'

--- a/.github/workflows/test_no_vulns.yml
+++ b/.github/workflows/test_no_vulns.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Test binary scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@show_summary_on_zero_vulns
         with:
           artifact_type: 'binary'
           artifact_path: 'entrypoint/tests/test_data/artifacts/binaries/test_go_binary'

--- a/entrypoint/entrypoint/orchestrator.py
+++ b/entrypoint/entrypoint/orchestrator.py
@@ -60,7 +60,7 @@ def post_dockerfile_step_summary(args, total_vulns):
             with open(args.out_dockerfile_scan_md, "r") as f:
                 dockerfile_markdown = f.read()
         except Exception as e:
-            logging.debug(e) # can be spammy, so set as debug log
+            logging.debug(e)  # can be spammy, so set as debug log
             return
 
         if not dockerfile_markdown:
@@ -379,10 +379,6 @@ def write_pkg_vuln_report_csv(args, criticals, highs, mediums, lows, others):
 
 
 def write_pkg_vuln_report_markdown(args, total_vulns, criticals, highs, mediums, lows, others):
-    if int(total_vulns) == 0:
-        logging.info(f"skipping package vulnerability markdown report because no vulnerabilities were detected")
-        return None
-
     with open(args.out_scan, "r") as f:
         inspector_scan = json.load(f)
         vulns = pkg_vuln.vulns_to_obj(inspector_scan)

--- a/entrypoint/entrypoint/orchestrator.py
+++ b/entrypoint/entrypoint/orchestrator.py
@@ -422,8 +422,8 @@ def print_vuln_count_summary(args, total_vulns, criticals, highs, mediums, lows,
     print(findings)
 
 
-def post_pkg_vuln_github_actions_step_summary(args, total_vulns, markdown):
-    if args.display_vuln_findings == "enabled" and total_vulns > 0:
+def post_pkg_vuln_github_actions_step_summary(args, markdown):
+    if args.display_vuln_findings == "enabled":
         logging.info("posting Inspector scan findings to GitHub Actions step summary page")
         pkg_vuln.post_github_step_summary(markdown)
 

--- a/entrypoint/entrypoint/orchestrator.py
+++ b/entrypoint/entrypoint/orchestrator.py
@@ -38,7 +38,7 @@ def execute(args) -> int:
     set_github_actions_output('inspector_scan_results_csv', args.out_scan_csv)
 
     pkg_vuln_markdown = write_pkg_vuln_report_markdown(args, total_vulns, criticals, highs, mediums, lows, others)
-    post_pkg_vuln_github_actions_step_summary(args, total_vulns, pkg_vuln_markdown)
+    post_pkg_vuln_github_actions_step_summary(args, pkg_vuln_markdown)
     set_github_actions_output('inspector_scan_results_markdown', args.out_scan_markdown)
 
     dockerfile.write_dockerfile_report_csv(args.out_scan, args.out_dockerfile_scan_csv)

--- a/entrypoint/entrypoint/orchestrator.py
+++ b/entrypoint/entrypoint/orchestrator.py
@@ -381,7 +381,7 @@ def write_pkg_vuln_report_csv(args, criticals, highs, mediums, lows, others):
 def write_pkg_vuln_report_markdown(args, total_vulns, criticals, highs, mediums, lows, others):
     if int(total_vulns) == 0:
         logging.info(f"skipping package vulnerability markdown report because no vulnerabilities were detected")
-        return
+        return None
 
     with open(args.out_scan, "r") as f:
         inspector_scan = json.load(f)

--- a/entrypoint/entrypoint/pkg_vuln.py
+++ b/entrypoint/entrypoint/pkg_vuln.py
@@ -340,7 +340,7 @@ def to_markdown(vulns,
     markdown += "\n\n"
 
     if not vulns:
-        markdown += ":green_circle: Your resource was scanned with Amazon Inspector and no vulnerabilities were detected."
+        markdown += ":green_circle: Your artifact was scanned with Amazon Inspector and no vulnerabilities were detected."
         markdown += "\n\n"
         return markdown
 

--- a/entrypoint/entrypoint/pkg_vuln.py
+++ b/entrypoint/entrypoint/pkg_vuln.py
@@ -422,12 +422,12 @@ def sort_vulns(vulns):
 
 
 def post_github_step_summary(markdown):
-    job_summary_file = "/tmp/inspector.md"
+    step_summary_path = "/tmp/inspector.md"
     if os.getenv('GITHUB_ACTIONS'):
-        job_summary_file = os.environ["GITHUB_STEP_SUMMARY"]
+        step_summary_path = os.environ["GITHUB_STEP_SUMMARY"]
 
     try:
-        with open(job_summary_file, "a") as f:
+        with open(step_summary_path, "a") as f:
             f.write(markdown)
     except Exception as e:
         logging.error(e)

--- a/entrypoint/entrypoint/pkg_vuln.py
+++ b/entrypoint/entrypoint/pkg_vuln.py
@@ -339,15 +339,15 @@ def to_markdown(vulns,
     markdown += f"| Other    | {others}|\n"
     markdown += "\n\n"
 
-    # create vulnerability details table
-    markdown += "## Vulnerability Findings\n\n"
-
-    markdown += "| ID | Severity | [CVSS](https://www.first.org/cvss/) | Installed Package ([PURL](https://github.com/package-url/purl-spec/tree/master?tab=readme-ov-file#purl)) | Fixed Package | Path | [EPSS](https://www.first.org/epss/) | Exploit Available | Exploit Last Seen | CWEs |\n"
-    markdown += "|----------|-------|-------|-------|-------|-------|-------|-------|-------|-------|\n"
-
     if not vulns:
+        markdown += ":green_circle: Your resource was scanned with Amazon Inspector and no vulnerabilities were detected."
         markdown += "\n\n"
         return markdown
+
+    # create vulnerability details table
+    markdown += "## Vulnerability Findings\n\n"
+    markdown += "| ID | Severity | [CVSS](https://www.first.org/cvss/) | Installed Package ([PURL](https://github.com/package-url/purl-spec/tree/master?tab=readme-ov-file#purl)) | Fixed Package | Path | [EPSS](https://www.first.org/epss/) | Exploit Available | Exploit Last Seen | CWEs |\n"
+    markdown += "|----------|-------|-------|-------|-------|-------|-------|-------|-------|-------|\n"
 
     # sort vulns by CVSS score
     vulns = sort_vulns(vulns)
@@ -421,10 +421,7 @@ def sort_vulns(vulns):
     return sorted_vulns
 
 
-def post_github_step_summary(markdown=None):
-    if markdown is None:
-        markdown = get_zero_vuln_summary_table()
-
+def post_github_step_summary(markdown):
     job_summary_file = "/tmp/inspector.md"
     if os.getenv('GITHUB_ACTIONS'):
         job_summary_file = os.environ["GITHUB_STEP_SUMMARY"]
@@ -456,13 +453,3 @@ def get_pkg_vulns(inspector_scan_vulns: dict):
         pkg_vulns.append(vuln)
 
     return pkg_vulns
-
-
-def get_zero_vuln_summary_table() -> str:
-    markdown = "## Vulnerability Counts by Severity\n\n"
-    markdown += "| Severity | Count |\n"
-    markdown += "|----------|-------|\n"
-    for severity in ["Critical", "High", "Medium", "Low", "Other"]:
-        markdown += f"| {severity} | 0 |\n"
-    markdown += "\n\n"
-    return markdown

--- a/entrypoint/entrypoint/pkg_vuln.py
+++ b/entrypoint/entrypoint/pkg_vuln.py
@@ -421,9 +421,9 @@ def sort_vulns(vulns):
     return sorted_vulns
 
 
-def post_github_step_summary(markdown="null"):
-    if markdown == "null":
-        return
+def post_github_step_summary(markdown=None):
+    if markdown is None:
+        markdown = get_zero_vuln_summary_table()
 
     job_summary_file = "/tmp/inspector.md"
     if os.getenv('GITHUB_ACTIONS'):
@@ -456,3 +456,13 @@ def get_pkg_vulns(inspector_scan_vulns: dict):
         pkg_vulns.append(vuln)
 
     return pkg_vulns
+
+
+def get_zero_vuln_summary_table() -> str:
+    markdown = "## Vulnerability Counts by Severity\n\n"
+    markdown += "| Severity | Count |\n"
+    markdown += "|----------|-------|\n"
+    for severity in ["Critical", "High", "Medium", "Low", "Other"]:
+        markdown += f"| {severity} | 0 |\n"
+    markdown += "\n\n"
+    return markdown

--- a/entrypoint/tests/test_pkg_vuln.py
+++ b/entrypoint/tests/test_pkg_vuln.py
@@ -1,4 +1,5 @@
 import json
+import os
 import unittest
 
 from entrypoint import pkg_vuln
@@ -37,6 +38,24 @@ class ConverterTestCase(unittest.TestCase):
                 vulns = pkg_vuln.vulns_to_obj(inspector_scan)
                 self.assertTrue(vulns != None)
 
+    def test_post_github_step_summary_no_vulns(self):
+
+        dst_markdown_with_zero_vulns = "/tmp/inspector.md"
+        cleanup_stale_markdown_report(dst_markdown_with_zero_vulns)
+
+        markdown_with_zero_vulns = None
+        pkg_vuln.post_github_step_summary(markdown_with_zero_vulns)
+
+        expected = pkg_vuln.get_zero_vuln_summary_table()
+        received = ""
+
+        with open(dst_markdown_with_zero_vulns, "r") as f:
+            received = f.read()
+
+        self.assertEqual(expected, received)
+
+        cleanup_stale_markdown_report(dst_markdown_with_zero_vulns)
+
 
 def get_scan_body(test_file):
     # test_file = "tests/test_data/artifacts/containers/dockerfile_checks/inspector-scan-cdx.json"
@@ -45,6 +64,13 @@ def get_scan_body(test_file):
     scan_body = inspector_scan_dict["sbom"]
     pkg_vuln.fatal_assert(scan_body != None, "expected JSON with key 'sbom' but it was not found")
     return scan_body
+
+
+def cleanup_stale_markdown_report(path):
+    try:
+        os.remove(path)
+    except:
+        return
 
 
 if __name__ == '__main__':

--- a/entrypoint/tests/test_pkg_vuln.py
+++ b/entrypoint/tests/test_pkg_vuln.py
@@ -40,21 +40,29 @@ class ConverterTestCase(unittest.TestCase):
 
     def test_post_github_step_summary_no_vulns(self):
 
-        dst_markdown_with_zero_vulns = "/tmp/inspector.md"
-        cleanup_stale_markdown_report(dst_markdown_with_zero_vulns)
+        markdown_dst_path = "/tmp/inspector.md"
+        cleanup_stale_markdown_report(markdown_dst_path)
 
-        markdown_with_zero_vulns = None
-        pkg_vuln.post_github_step_summary(markdown_with_zero_vulns)
+        zero_vuln_summary_md = pkg_vuln.to_markdown(vulns=None,
+                                                    artifact_name="test_image:latest",
+                                                    artifact_type="container",
+                                                    artifact_hash="null",
+                                                    build_id="null",
+                                                    criticals="0",
+                                                    highs="0",
+                                                    mediums="0",
+                                                    lows="0",
+                                                    others="0")
 
-        expected = pkg_vuln.get_zero_vuln_summary_table()
-        received = ""
-
-        with open(dst_markdown_with_zero_vulns, "r") as f:
-            received = f.read()
-
-        self.assertEqual(expected, received)
-
-        cleanup_stale_markdown_report(dst_markdown_with_zero_vulns)
+        expected_list = ["| Critical | 0|",
+                         "| High     | 0|",
+                         "| Medium   | 0|",
+                         "| Low      | 0|",
+                         "| Other    | 0|",
+                         ]
+        for expected in expected_list:
+            self.assertIn(expected, zero_vuln_summary_md)
+        cleanup_stale_markdown_report(markdown_dst_path)
 
 
 def get_scan_body(test_file):


### PR DESCRIPTION
## Description

Currently the GitHub Actions plugin does not display the vulnerability summary table when zero vulnerabilities have been found. This creates friction for customers who prefer the zero vulnerability table because it clearly communicates that a scan was executed and zero vulnerabilities were found.

These changes now create the summary table when zero vulnerabilities are detected.

## Example Output

See here for example output:

https://github.com/aws-actions/vulnerability-scan-github-action-for-amazon-inspector/actions/runs/9548575324

## Related Issues

https://github.com/aws-actions/vulnerability-scan-github-action-for-amazon-inspector/issues/59