### PR TITLE
Support aarch64 systems

### DIFF
--- a/entrypoint/entrypoint/orchestrator.py
+++ b/entrypoint/entrypoint/orchestrator.py
@@ -120,34 +120,30 @@ def download_install_sbomgen(sbomgen_version: str, install_dst: str) -> bool:
     return True
 
 
-def get_sbomgen_arch(cpu_arch):
+def get_sbomgen_arch(host_cpu):
     """
     get the CPU architecture for the
     inspector-sbomgen release binary
     based on the host system's CPU arch
     """
-    if not cpu_arch:
+    if not host_cpu:
         return None
 
-    # TODO: make a list of supported platforms, mapped to their sbomgen platform
-    # iterate over the list instead of having a bunch of branching statements
-    sbomgen_arch = ""
-    if "x86_64" in cpu_arch:
-        sbomgen_arch = "amd64"
+    # map the host platform's CPU architecture to
+    # the correct sbomgen binary architecture
+    architecture_map = {
+        "x86_64": "amd64",
+        "amd64": "amd64",
+        "arm64": "arm64",
+        "aarch64": "arm64"
+    }
 
-    elif "amd64" in cpu_arch:
-        sbomgen_arch = "amd64"
+    for supported_cpu in architecture_map:
+        if host_cpu.lower() == supported_cpu:
+            sbomgen_arch = architecture_map[supported_cpu]
+            return sbomgen_arch
 
-    elif "arm64" in cpu_arch:
-        sbomgen_arch = "arm64"
-
-    elif "aarch64" in cpu_arch:
-        sbomgen_arch = "arm64"
-
-    else:
-        return None
-
-    return sbomgen_arch
+    return None
 
 
 def invoke_sbomgen(args) -> int:

--- a/entrypoint/entrypoint/orchestrator.py
+++ b/entrypoint/entrypoint/orchestrator.py
@@ -4,6 +4,7 @@ import logging
 import os
 import platform
 import shutil
+import sys
 import tempfile
 
 from entrypoint import dockerfile
@@ -80,18 +81,13 @@ def post_dockerfile_step_summary(args, total_vulns):
 
 def download_install_sbomgen(sbomgen_version: str, install_dst: str) -> bool:
     cpu_arch = platform.machine()
-    if "x86_64" in cpu_arch:
-        cpu_arch = "amd64"
-
-    elif "arm64" in cpu_arch:
-        cpu_arch = "arm64"
-
-    else:
-        logging.error(f"expected a CPU architecture of x86_64, arm64, or amd64, but received: {cpu_arch}")
-        return False
+    sbomgen_arch = get_sbomgen_arch(cpu_arch)
+    if not sbomgen_arch:
+        logging.error(f"expected a CPU architecture of x86_64, amd64, arm64, or aarch64, but received: {cpu_arch}")
+        sys.exit(1)
 
     # download sbomgen
-    url = installer.get_sbomgen_url("Linux", cpu_arch, sbomgen_version)
+    url = installer.get_sbomgen_url("Linux", sbomgen_arch, sbomgen_version)
     dst = tempfile.gettempdir()
     dst = os.path.join(dst, "inspector-sbomgen.zip")
     ret = installer.download_sbomgen(url, dst)
@@ -122,6 +118,36 @@ def download_install_sbomgen(sbomgen_version: str, install_dst: str) -> bool:
     logging.debug(f"setting inspector-sbomgen install path to: {install_dst}")
     installer.set_sbomgen_install_path(install_dst)
     return True
+
+
+def get_sbomgen_arch(cpu_arch):
+    """
+    get the CPU architecture for the
+    inspector-sbomgen release binary
+    based on the host system's CPU arch
+    """
+    if not cpu_arch:
+        return None
+
+    # TODO: make a list of supported platforms, mapped to their sbomgen platform
+    # iterate over the list instead of having a bunch of branching statements
+    sbomgen_arch = ""
+    if "x86_64" in cpu_arch:
+        sbomgen_arch = "amd64"
+
+    elif "amd64" in cpu_arch:
+        sbomgen_arch = "amd64"
+
+    elif "arm64" in cpu_arch:
+        sbomgen_arch = "arm64"
+
+    elif "aarch64" in cpu_arch:
+        sbomgen_arch = "arm64"
+
+    else:
+        return None
+
+    return sbomgen_arch
 
 
 def invoke_sbomgen(args) -> int:

--- a/entrypoint/tests/test_orchestrator.py
+++ b/entrypoint/tests/test_orchestrator.py
@@ -119,13 +119,19 @@ class TestOrchestrator(unittest.TestCase):
     def test_get_sbomgen_arch(self):
 
         test_cases = [
-            # supported platforms
+            # supported platforms (ARM and Intel 64-bit)
             {"input": "x86_64", "expected": "amd64"},
             {"input": "amd64", "expected": "amd64"},
             {"input": "arm64", "expected": "arm64"},
             {"input": "aarch64", "expected": "arm64"},
 
-            # unsupported platforms
+            # test case insensitivity
+            {"input": "X86_64", "expected": "amd64"},
+            {"input": "AMD64", "expected": "amd64"},
+            {"input": "ARM64", "expected": "arm64"},
+            {"input": "aARCh64", "expected": "arm64"},
+
+            # unsupported platforms (32-bit, non-intel, non-arm)
             {"input": "arm", "expected": None},
             {"input": "armv6l", "expected": None},
             {"input": "armv7l", "expected": None},
@@ -144,6 +150,7 @@ class TestOrchestrator(unittest.TestCase):
 
             # malformed input
             {"input": "garbage", "expected": None},
+            {"input": "213123123123", "expected": None},
             {"input": "", "expected": None},
             {"input": None, "expected": None},
         ]

--- a/entrypoint/tests/test_orchestrator.py
+++ b/entrypoint/tests/test_orchestrator.py
@@ -116,6 +116,42 @@ class TestOrchestrator(unittest.TestCase):
             dockerfile.write_dockerfile_report_csv(args.out_scan, args.out_dockerfile_scan_csv)
             dockerfile.write_dockerfile_report_md(args.out_scan, args.out_dockerfile_scan_md)
 
+    def test_get_sbomgen_arch(self):
+
+        test_cases = [
+            # supported platforms
+            {"input": "x86_64", "expected": "amd64"},
+            {"input": "amd64", "expected": "amd64"},
+            {"input": "arm64", "expected": "arm64"},
+            {"input": "aarch64", "expected": "arm64"},
+
+            # unsupported platforms
+            {"input": "arm", "expected": None},
+            {"input": "armv6l", "expected": None},
+            {"input": "armv7l", "expected": None},
+            {"input": "armv8l", "expected": None},
+            {"input": "i386", "expected": None},
+            {"input": "i486", "expected": None},
+            {"input": "i586", "expected": None},
+            {"input": "i686", "expected": None},
+            {"input": "ppc", "expected": None},
+            {"input": "ppc64", "expected": None},
+            {"input": "ppc64le", "expected": None},
+            {"input": "sparc", "expected": None},
+            {"input": "sparc64", "expected": None},
+            {"input": "mips", "expected": None},
+            {"input": "mips64", "expected": None},
+
+            # malformed input
+            {"input": "garbage", "expected": None},
+            {"input": "", "expected": None},
+            {"input": None, "expected": None},
+        ]
+
+        for each_test in test_cases:
+            result = orchestrator.get_sbomgen_arch(each_test["input"])
+            self.assertEqual(result, each_test["expected"])
+
 
 def read_test_file(file: str) -> str:
     file_contents = ""


### PR DESCRIPTION
Before this change, the action would fail to download and install inspector-sbomgen when the user's CPU architecture is `aarch64`, even though `arm64` is supported (see issue #61 ).

This can be observed below:
```
$ uname -r
6.1.94-99.176.amzn2023.aarch64

$ python3 entrypoint/main.py

time="2024-06-27 18:09:00" level=info msg="downloading and installing inspector-sbomgen version latest" file="orchestrator.py:16"
time="2024-06-27 18:09:00" level=error msg="expected a CPU architecture of x86_64, arm64, or amd64, but received: aarch64" file="orchestrator.py:90"
time="2024-06-27 18:09:00" level=error msg="unable to download and install inspector-sbomgen" file="orchestrator.py:429"
```

After this change, the action correctly downloads and installs inspector-sbomgen on aarch64 systems:

```
$ uname -r
6.1.94-99.176.amzn2023.aarch64

$ python3 entrypoint/main.py

time="2024-06-27 18:10:24" level=info msg="downloading and installing inspector-sbomgen version latest" file="orchestrator.py:17"
time="2024-06-27 18:10:25" level=info msg="generating SBOM from artifact" file="orchestrator.py:21"
INFO[0000] Amazon Inspector SBOM Generator v1.2.1 - linux arm64 - Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved
INFO[0000] [/usr/local/bin/inspector-sbomgen directory --path ./ --outfile sbom.json --disable-progress-bar --timeout 600]
INFO[0000] writing log file to: /root/.inspector-sbomgen/logs/inspector-sbomgen-log_2024-06-27_18-10-25.txt
INFO[2024-06-27 18:10:25]coreV1.go:34: initializing target artifact
INFO[2024-06-27 18:10:25]coreV1.go:44: executing pre-processors
INFO[2024-06-27 18:10:25]directory.go:216: walking the artifact
INFO[2024-06-27 18:10:25]coreV1.go:53: analyzing artifact
INFO[2024-06-27 18:10:25]coreV1.go:62: executing post-processors
INFO[2024-06-27 18:10:25]coreV1.go:71: encoding findings
INFO[2024-06-27 18:10:25]directories.go:243: encoded 74 components
INFO[2024-06-27 18:10:25]directory.go:290: cleaning up file system artifacts
INFO[2024-06-27 18:10:25]cli.go:62: Elapsed time: 149ms
time="2024-06-27 18:10:25" level=info msg="scanning SBOM contents with Amazon Inspector" file="orchestrator.py:25"
```
