### PR TITLE
Show severity and score from providers in addition to NVD in the summary report

### DIFF
--- a/entrypoint/entrypoint/pkg_vuln.py
+++ b/entrypoint/entrypoint/pkg_vuln.py
@@ -10,6 +10,7 @@ import logging
 import os
 import urllib.parse
 
+from dataclasses import dataclass
 from io import StringIO
 from typing import List
 
@@ -36,6 +37,12 @@ class Vulnerability:
         self.exploit_available = "null"
         self.exploit_last_seen = "null"
         self.cwes = "null"
+
+
+@dataclass
+class CvssRating:
+    severity: str = "null"
+    cvss_score: str = "null"
 
 
 def vulns_to_obj(inspector_scan_json) -> List[Vulnerability]:
@@ -70,18 +77,7 @@ def vulns_to_obj(inspector_scan_json) -> List[Vulnerability]:
 
         # get vuln severity and EPSS score
         ratings = v.get("ratings")
-        if ratings:
-            nvd_severity = get_nvd_severity(ratings)
-            if nvd_severity:
-                vuln_obj.severity = nvd_severity
-
-            nvd_score = get_nvd_score(ratings)
-            if nvd_score:
-                vuln_obj.cvss_score = nvd_score
-
-            epss_score = get_epss_score(ratings)
-            if epss_score:
-                vuln_obj.epss_score = epss_score
+        add_ratings(ratings, vuln_obj)
 
         # get vulnerability published date
         published = v.get("created")
@@ -207,34 +203,37 @@ def getPropertyValueFromKey(vuln_json, key):
     return None
 
 
-def get_nvd_severity(ratings):
-    for rating in ratings:
-        source = rating.get("source")
-        if not source:
-            continue
+def add_ratings(ratings, vulnerability):
+    if ratings is None:
+        return
 
-        if source["name"] == "NVD":
+    rating = get_cvss_rating(ratings, vulnerability)
+    vulnerability.severity = rating.severity
+    vulnerability.cvss_score = rating.cvss_score
+
+    epss_score = get_epss_score(ratings)
+    if epss_score:
+        vulnerability.epss_score = epss_score
+
+
+def get_cvss_rating(ratings, vulnerability) -> CvssRating:
+    rating_provider_priority = [
+        'NVD',
+        'MITRE',
+        'AMAZON_INSPECTOR'
+    ]
+    for provider in rating_provider_priority:
+        for rating in ratings:
+            if rating['source']['name'] != provider:
+                continue
+
             severity = rating["severity"]
-            if severity:
-                return severity
-    return None
+            cvss_score = rating["score"] if rating['method'] == 'CVSSv31' else "null"
+            if severity and cvss_score:
+                return CvssRating(severity=severity, cvss_score=cvss_score)
 
-
-def get_nvd_score(ratings):
-    for rating in ratings:
-        source = rating.get("source")
-        if not source:
-            continue
-
-        method = rating.get("method")
-        if not method:
-            continue
-
-        if source["name"] == "NVD" and method == "CVSSv31":
-            score = rating["score"]
-            if score:
-                return score
-    return None
+    logging.info(f"No CVSS rating is provided for {vulnerability.vuln_id}")
+    return CvssRating()
 
 
 def get_epss_score(ratings):

--- a/entrypoint/tests/__init__.py
+++ b/entrypoint/tests/__init__.py
@@ -1,3 +1,8 @@
-from entrypoint import log_conf
+import logging
 
-log_conf.init(enable_verbose=True)
+
+logger = logging.getLogger()
+logger.setLevel(logging.ERROR)
+
+handler = logging.StreamHandler()
+handler.setLevel(logging.ERROR)

--- a/entrypoint/tests/test_pkg_vuln.py
+++ b/entrypoint/tests/test_pkg_vuln.py
@@ -64,6 +64,67 @@ class ConverterTestCase(unittest.TestCase):
             self.assertIn(expected, zero_vuln_summary_md)
         cleanup_stale_markdown_report(markdown_dst_path)
 
+    def test_get_rating(self):
+        tests = [
+            {
+                "name": "NVD should take a priority over other providers",
+                "ratings": [
+                    {
+                        "method": "CVSSv31",
+                        "score": 7.2,
+                        "severity": "high",
+                        "source": {"name": "MITRE"},
+                    },
+                    {
+                        "method": "CVSSv31",
+                        "score": 5.3,
+                        "severity": "medium",
+                        "source": {"name": "NVD"},
+                    },
+                    {
+                        "method": "other",
+                        "score": 0.00051,
+                        "severity": "none",
+                        "source": {"name": "EPSS"},
+                    },
+                ],
+                "expected": pkg_vuln.CvssRating("medium", 5.3),
+            },
+            {
+                "name": 'score should be "null" when method is "other"',
+                "ratings": [
+                    {
+                        "method": "other",
+                        "severity": "medium",
+                        "source": {"name": "AMAZON_INSPECTOR"},
+                    },
+                    {
+                        "method": "other",
+                        "score": 0.00051,
+                        "severity": "none",
+                        "source": {"name": "EPSS"},
+                    },
+                ],
+                "expected": pkg_vuln.CvssRating("medium"),
+            },
+            {
+                "name": 'rating should be "null" when neither NVD, MITRE, nor AMAZON_INSPECTOR provides a rating',
+                "ratings": [
+                    {
+                        "method": "other",
+                        "score": 0.00051,
+                        "severity": "none",
+                        "source": {"name": "EPSS"},
+                    },
+                ],
+                "expected": pkg_vuln.CvssRating(),
+            },
+        ]
+        for test in tests:
+            with self.subTest(msg=test["name"]):
+                rating = pkg_vuln.get_cvss_rating(test["ratings"], pkg_vuln.Vulnerability())
+                self.assertEqual(test["expected"], rating)
+
 
 def get_scan_body(test_file):
     # test_file = "tests/test_data/artifacts/containers/dockerfile_checks/inspector-scan-cdx.json"


### PR DESCRIPTION
## Description
Show severity and score from providers in addition to NVD in the summary report in GitHub Actions.
The prioritize severity is the following order:
1. NVD
2. MITRE
3. AMAZON_INSPECTOR (As Amazon Inspector does not provide score, only display severity)

If severity is not provided by any provider, the severity and score will remain empty.

Related Issues: https://github.com/aws-actions/vulnerability-scan-github-action-for-amazon-inspector/issues/68


Log:
```
time="2024-07-22 15:06:14" level=info msg="downloading and installing inspector-sbomgen version latest" file="orchestrator.py:17"
time="2024-07-22 15:06:15" level=info msg="generating SBOM from artifact" file="orchestrator.py:21"
INFO[0000] Amazon Inspector SBOM Generator v1.3.1 - linux arm64 - Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved
INFO[0000] [/usr/local/bin/inspector-sbomgen directory --path /tmp/python-proj --outfile /tmp/sbom_9943125441.json --disable-progress-bar --timeout 600]
INFO[0000] writing log file to: /Users/kensugim/.inspector-sbomgen/logs/inspector-sbomgen-log_2024-07-22_15-06-15.txt
INFO[2024-07-22 15:06:15]coreV1.go:34: initializing target artifact
INFO[2024-07-22 15:06:15]coreV1.go:44: executing pre-processors
INFO[2024-07-22 15:06:15]directory.go:180: walking the artifact
INFO[2024-07-22 15:06:15]coreV1.go:53: analyzing artifact
INFO[2024-07-22 15:06:15]coreV1.go:62: executing post-processors
INFO[2024-07-22 15:06:15]coreV1.go:71: encoding findings
INFO[2024-07-22 15:06:15]directories.go:243: encoded 19 components
INFO[2024-07-22 15:06:15]directory.go:242: cleaning up file system artifacts
INFO[2024-07-22 15:06:15]cli.go:62: Elapsed time: 130ms
time="2024-07-22 15:06:15" level=info msg="setting github actions output: artifact_sbom:/tmp/sbom_9943125441.json" file="orchestrator.py:233"
sh: line 1: : No such file or directory
time="2024-07-22 15:06:15" level=info msg="scanning SBOM contents with Amazon Inspector" file="orchestrator.py:25"
time="2024-07-22 15:06:16" level=info msg="setting github actions output: inspector_scan_results:/tmp/inspector_scan_9943125441.json" file="orchestrator.py:233"
sh: line 1: : No such file or directory
time="2024-07-22 15:06:16" level=info msg="tallying vulnerabilities" file="orchestrator.py:30"

    ------------------------------------
    Amazon Inspector Scan Summary:
    Artifact Name: /tmp/python-proj
    Artifact Type: repository
    2024-07-22 15:06:16
    ------------------------------------
    Total Vulnerabilities: 19
    Critical:   3
    High:       10
    Medium:     6
    Low:        0
    Other:      0

time="2024-07-22 15:06:16" level=info msg="setting github actions output: vulnerability_threshold_exceeded:0" file="orchestrator.py:233"
sh: line 1: : No such file or directory
time="2024-07-22 15:06:16" level=info msg="writing package vulnerability CSV report to: /tmp/inspector_scan_9943125441.csv" file="orchestrator.py:398"
time="2024-07-22 15:06:16" level=info msg="setting github actions output: inspector_scan_results_csv:/tmp/inspector_scan_9943125441.csv" file="orchestrator.py:233"
sh: line 1: : No such file or directory
time="2024-07-22 15:06:16" level=info msg="writing package vulnerability markdown report to: /tmp/inspector_scan_9943125441.md" file="orchestrator.py:416"
time="2024-07-22 15:06:16" level=info msg="posting Inspector scan findings to GitHub Actions step summary page" file="orchestrator.py:445"
time="2024-07-22 15:06:16" level=error msg="[Errno 21] Is a directory: '/tmp'" file="pkg_vuln.py:432"
time="2024-07-22 15:06:16" level=info msg="setting github actions output: inspector_scan_results_markdown:/tmp/inspector_scan_9943125441.md" file="orchestrator.py:233"
sh: line 1: : No such file or directory
time="2024-07-22 15:06:16" level=info msg="skipping dockerfile vulnerability CSV report because no vulnerabilities were detected" file="dockerfile.py:318"
time="2024-07-22 15:06:16" level=info msg="setting github actions output: inspector_dockerile_scan_results_csv:/tmp/inspector_dockerfile_scan_9943125441.csv" file="orchestrator.py:233"
sh: line 1: : No such file or directory
time="2024-07-22 15:06:16" level=info msg="skipping dockerfile vulnerability MD report because no vulnerabilities were detected" file="dockerfile.py:332"
time="2024-07-22 15:06:16" level=info msg="setting github actions output: inspector_dockerile_scan_results_markdown:/tmp/inspector_dockerfile_scan_9943125441.md" file="orchestrator.py:233"
sh: line 1: : No such file or directory
time="2024-07-22 15:06:16" level=info msg="posting Inspector Dockerfile scan findings to GitHub Actions step summary page" file="orchestrator.py:57"
```

