### PR TITLE
Handle unknown severity and null severity as untriaged / Add source c…

### DIFF
--- a/entrypoint/entrypoint/pkg_vuln.py
+++ b/entrypoint/entrypoint/pkg_vuln.py
@@ -15,6 +15,19 @@ from io import StringIO
 from typing import List
 
 
+class CvssSourceProvider:
+    NVD = 'NVD'
+    MITRE = 'MITRE'
+    AMAZON_INSPECTOR = 'AMAZON_INSPECTOR'
+
+    DEFAULT_PROVIDER = NVD
+
+
+class CvssSeverity:
+    UNTRIAGED = "untriaged"
+    UNKNOWN = "unknown"
+
+
 class Vulnerability:
     """
     Vulnerability is an object for marshalling
@@ -26,6 +39,7 @@ class Vulnerability:
     def __init__(self):
         self.vuln_id = "null"
         self.severity = "null"
+        self.severity_provider = "null"
         self.cvss_score = "null"
         self.published = "null"
         self.modified = "null"
@@ -41,7 +55,8 @@ class Vulnerability:
 
 @dataclass
 class CvssRating:
-    severity: str = "null"
+    severity: str = CvssSeverity.UNTRIAGED
+    provider: str = CvssSourceProvider.DEFAULT_PROVIDER
     cvss_score: str = "null"
 
 
@@ -209,6 +224,7 @@ def add_ratings(ratings, vulnerability):
 
     rating = get_cvss_rating(ratings, vulnerability)
     vulnerability.severity = rating.severity
+    vulnerability.severity_provider = rating.provider
     vulnerability.cvss_score = rating.cvss_score
 
     epss_score = get_epss_score(ratings)
@@ -227,10 +243,10 @@ def get_cvss_rating(ratings, vulnerability) -> CvssRating:
             if rating['source']['name'] != provider:
                 continue
 
-            severity = rating["severity"]
+            severity = CvssSeverity.UNTRIAGED if rating["severity"] == CvssSeverity.UNKNOWN else rating["severity"]
             cvss_score = rating["score"] if rating['method'] == 'CVSSv31' else "null"
             if severity and cvss_score:
-                return CvssRating(severity=severity, cvss_score=cvss_score)
+                return CvssRating(severity=severity, provider=provider, cvss_score=cvss_score)
 
     logging.info(f"No CVSS rating is provided for {vulnerability.vuln_id}")
     return CvssRating()
@@ -279,7 +295,7 @@ def to_csv(vulns,
     csv_writer.writerow(vuln_summary)
 
     # write the header into the CSV
-    header = ["ID", "Severity", "CVSS",
+    header = ["ID", "Severity", "Source", "CVSS",
               "Installed Package", "Fixed Package",
               "Path", "EPSS", "Exploit Available",
               "Exploit Last Seen", "CWEs"]
@@ -289,7 +305,7 @@ def to_csv(vulns,
     if vulns:
         for v in vulns:
             # if package vuln
-            row = [v.vuln_id, v.severity, v.cvss_score,
+            row = [v.vuln_id, v.severity, v.severity_provider, v.cvss_score,
                    v.installed_ver, v.fixed_ver,
                    v.pkg_path, v.epss_score, v.exploit_available,
                    v.exploit_last_seen, v.cwes
@@ -345,15 +361,15 @@ def to_markdown(vulns,
 
     # create vulnerability details table
     markdown += "## Vulnerability Findings\n\n"
-    markdown += "| ID | Severity | [CVSS](https://www.first.org/cvss/) | Installed Package ([PURL](https://github.com/package-url/purl-spec/tree/master?tab=readme-ov-file#purl)) | Fixed Package | Path | [EPSS](https://www.first.org/epss/) | Exploit Available | Exploit Last Seen | CWEs |\n"
-    markdown += "|----------|-------|-------|-------|-------|-------|-------|-------|-------|-------|\n"
+    markdown += "| ID | Severity | Source | [CVSS](https://www.first.org/cvss/) | Installed Package ([PURL](https://github.com/package-url/purl-spec/tree/master?tab=readme-ov-file#purl)) | Fixed Package | Path | [EPSS](https://www.first.org/epss/) | Exploit Available | Exploit Last Seen | CWEs |\n"
+    markdown += "| ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- |\n"
 
     # sort vulns by CVSS score
     vulns = sort_vulns(vulns)
 
     # append each row to the vulnerability details table
     for v in vulns:
-        markdown += f"|{v.vuln_id}| {clean_null(v.severity)} | {clean_null(v.cvss_score)} | {merge_cell(v.installed_ver)} | {merge_cell(v.fixed_ver)} | {merge_cell(clean_null(v.pkg_path))} | {clean_null(v.epss_score)} | {clean_null(v.exploit_available)} | {clean_null(v.exploit_last_seen)} | {(merge_cell(clean_null(v.cwes)))} | \n"
+        markdown += f"| {v.vuln_id} | {clean_null(v.severity)} | {clean_null(v.severity_provider)} | {clean_null(v.cvss_score)} | {merge_cell(v.installed_ver)} | {merge_cell(v.fixed_ver)} | {merge_cell(clean_null(v.pkg_path))} | {clean_null(v.epss_score)} | {clean_null(v.exploit_available)} | {clean_null(v.exploit_last_seen)} | {(merge_cell(clean_null(v.cwes)))} | \n"
 
     markdown += "\n\n"
     return markdown

--- a/entrypoint/tests/test_pkg_vuln.py
+++ b/entrypoint/tests/test_pkg_vuln.py
@@ -88,14 +88,14 @@ class ConverterTestCase(unittest.TestCase):
                         "source": {"name": "EPSS"},
                     },
                 ],
-                "expected": pkg_vuln.CvssRating("medium", 5.3),
+                "expected": pkg_vuln.CvssRating("medium", "NVD", 5.3),
             },
             {
-                "name": 'score should be "null" when method is "other"',
+                "name": 'score should be "null" and severity should be "untriaged" when method is "other" and severity is "unknown"',
                 "ratings": [
                     {
                         "method": "other",
-                        "severity": "medium",
+                        "severity": "unknown",
                         "source": {"name": "AMAZON_INSPECTOR"},
                     },
                     {
@@ -105,10 +105,10 @@ class ConverterTestCase(unittest.TestCase):
                         "source": {"name": "EPSS"},
                     },
                 ],
-                "expected": pkg_vuln.CvssRating("medium"),
+                "expected": pkg_vuln.CvssRating("untriaged", "AMAZON_INSPECTOR", "null"),
             },
             {
-                "name": 'rating should be "null" when neither NVD, MITRE, nor AMAZON_INSPECTOR provides a rating',
+                "name": 'rating should be "null" and severity is not provided when no CVSS rating is provided',
                 "ratings": [
                     {
                         "method": "other",
@@ -117,7 +117,7 @@ class ConverterTestCase(unittest.TestCase):
                         "source": {"name": "EPSS"},
                     },
                 ],
-                "expected": pkg_vuln.CvssRating(),
+                "expected": pkg_vuln.CvssRating("untriaged", "NVD", "null"),
             },
         ]
         for test in tests:


### PR DESCRIPTION
## Overview
Improved vulnerability details table.
- Render severity as "untriaged" when severity returned AmazonInspector is unknown or is not provided.
- Add "Source" column to render provider of CVSS rating.

## Testing
- `make test`
- Build the docker image for the github actions and run it locally.

![Screenshot 2024-07-26 at 2 27 58 PM](https://github.com/user-attachments/assets/a47f17b8-68a3-4f8f-bba0-28b4399039ac)
