### PR TITLE
Write CSV with no vulns

### DIFF
--- a/.github/workflows/test_containers.yml
+++ b/.github/workflows/test_containers.yml
@@ -35,9 +35,9 @@ jobs:
         uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.3
         with:
           artifact_type: 'container'
-          artifact_path: 'ubuntu:14.04'
+          artifact_path: 'alpine:latest'
           display_vulnerability_findings: "enabled"
-          sbomgen_version: "1.3.1"
+          sbomgen_version: "1.4.0"
 
       - name: Display scan results (CSV)
         run: cat ${{ steps.inspector.outputs.inspector_scan_results_csv }}

--- a/.github/workflows/test_containers.yml
+++ b/.github/workflows/test_containers.yml
@@ -35,24 +35,12 @@ jobs:
         uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.3
         with:
           artifact_type: 'container'
-          artifact_path: 'alpine:latest'
+          artifact_path: 'ubuntu:14.04'
           display_vulnerability_findings: "enabled"
-          sbomgen_version: "1.4.0"
+          sbomgen_version: "1.3.1"
 
-       - name: Display CycloneDX SBOM (JSON)
-         run: cat ${{ steps.inspector.outputs.artifact_sbom }}
-
-       - name: Display Inspector vulnerability scan results (JSON)
-         run: cat ${{ steps.inspector.outputs.inspector_scan_results }}
-
-       - name: Display Inspector vulnerability scan results (CSV)
-         run: cat ${{ steps.inspector.outputs.inspector_scan_results_csv }}
-
-       - name: Display Inspector vulnerability scan results (Markdown)
-         run: cat ${{ steps.inspector.outputs.inspector_scan_results_markdown }}
-
-      - name: Display scan results
-        run: cat ${{ steps.inspector.outputs.inspector_scan_results }}
+      - name: Display scan results (CSV)
+        run: cat ${{ steps.inspector.outputs.inspector_scan_results_csv }}
 
       - name: Validate scan content
         run: python3 validator/validate_inspector_scan.py --file ${{ steps.inspector.outputs.inspector_scan_results }}

--- a/.github/workflows/test_containers.yml
+++ b/.github/workflows/test_containers.yml
@@ -35,9 +35,21 @@ jobs:
         uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.3
         with:
           artifact_type: 'container'
-          artifact_path: 'ubuntu:14.04'
+          artifact_path: 'alpine:latest'
           display_vulnerability_findings: "enabled"
-          sbomgen_version: "1.3.1"
+          sbomgen_version: "1.4.0"
+
+       - name: Display CycloneDX SBOM (JSON)
+         run: cat ${{ steps.inspector.outputs.artifact_sbom }}
+
+       - name: Display Inspector vulnerability scan results (JSON)
+         run: cat ${{ steps.inspector.outputs.inspector_scan_results }}
+
+       - name: Display Inspector vulnerability scan results (CSV)
+         run: cat ${{ steps.inspector.outputs.inspector_scan_results_csv }}
+
+       - name: Display Inspector vulnerability scan results (Markdown)
+         run: cat ${{ steps.inspector.outputs.inspector_scan_results_markdown }}
 
       - name: Display scan results
         run: cat ${{ steps.inspector.outputs.inspector_scan_results }}

--- a/entrypoint/entrypoint/orchestrator.py
+++ b/entrypoint/entrypoint/orchestrator.py
@@ -344,10 +344,6 @@ def install_sbomgen(args):
 
 
 def write_pkg_vuln_report_csv(out_scan_csv, scan_result: exporter.InspectorScanResult):
-    if scan_result.total_vulns() == 0:
-        logging.info("skipping package vulnerability CSV report because no vulnerabilities were detected")
-        return
-
     csv_output = exporter.to_csv(scan_result)
 
     logging.info(f"writing package vulnerability CSV report to: {out_scan_csv}")


### PR DESCRIPTION
Currently this action does not write CSV files if no vulns are found; however, the JSON and markdown files are written regardless, causing inconsistency that raises confusion for users (#85).

After this change, the CSV file is written regardless if there are vulns or not.