### PR TITLE
Write Dockerfile CSV and Markdown on no vulns

### DIFF
--- a/entrypoint/entrypoint/dockerfile.py
+++ b/entrypoint/entrypoint/dockerfile.py
@@ -314,9 +314,6 @@ def dockerfile_vulns_to_csv(dockerfile_vulns):
 
 def write_dockerfile_report_csv(inspector_scan_path, dst_file):
     dockerfile_vulns = get_dockerfile_vulns(inspector_scan_path)
-    if len(dockerfile_vulns) == 0:
-        logging.info(f"skipping dockerfile vulnerability CSV report because no vulnerabilities were detected")
-        return False
 
     csv_output = dockerfile_vulns_to_csv(dockerfile_vulns)
 
@@ -328,9 +325,6 @@ def write_dockerfile_report_csv(inspector_scan_path, dst_file):
 
 def write_dockerfile_report_md(inspector_scan_path, dst_file):
     dockerfile_vulns = get_dockerfile_vulns(inspector_scan_path)
-    if len(dockerfile_vulns) == 0:
-        logging.info(f"skipping dockerfile vulnerability MD report because no vulnerabilities were detected")
-        return False
 
     markdown_report = get_markdown_header()
     for vuln in dockerfile_vulns:

--- a/entrypoint/tests/test_dockerfile_checks.py
+++ b/entrypoint/tests/test_dockerfile_checks.py
@@ -152,7 +152,7 @@ class TestDockerfileChecks(unittest.TestCase):
                 write_counter += 1
         os.remove(dst)
 
-        expected_writes = 2
+        expected_writes = 4
         self.assertEqual(expected_writes, write_counter)
 
     def test_write_dockerfile_report_md(self):
@@ -170,7 +170,7 @@ class TestDockerfileChecks(unittest.TestCase):
                 write_counter += 1
         os.remove(dst)
 
-        expected_writes = 2
+        expected_writes = 4
         self.assertEqual(expected_writes, write_counter)
 
 


### PR DESCRIPTION
Before this change, Dockerfile vuln reports were not written to disk when zero vulns were found.
This is inconsistent behavior and raises confusion for users (see #85).
After this change, Dockerfile vuln reports (markdown and CSV) are always written to disk.