### PR TITLE
Omit Dockerfile table on no vulns

### DIFF
--- a/entrypoint/entrypoint/dockerfile.py
+++ b/entrypoint/entrypoint/dockerfile.py
@@ -263,6 +263,9 @@ def get_markdown_header() -> str:
     s += "|---|---|---|---|---|\n"
     return s
 
+def get_markdown_header_no_vulns() -> str:
+    s = "## Dockerfile Findings\n"
+    return s
 
 def get_dockerfile_vulns(inspector_scan_path):
     vuln_objects = []
@@ -326,14 +329,16 @@ def write_dockerfile_report_csv(inspector_scan_path, dst_file):
 def write_dockerfile_report_md(inspector_scan_path, dst_file):
     dockerfile_vulns = get_dockerfile_vulns(inspector_scan_path)
 
-    markdown_report = get_markdown_header()
-    for vuln in dockerfile_vulns:
-        row = vuln_to_markdown_row(vuln)
-        markdown_report += row
-
+    markdown_report = ""
     if len(dockerfile_vulns) == 0:
+        markdown_report = get_markdown_header_no_vulns()
         row = "\n\n:green_circle: Amazon Inspector scanned for security issues in Dockerfiles and no issues were found."
         markdown_report += row
+    else:
+        markdown_report = get_markdown_header()
+        for vuln in dockerfile_vulns:
+            row = vuln_to_markdown_row(vuln)
+            markdown_report += row
 
     logging.info(f"writing Dockerfile vulnerability markdown report to: {dst_file}")
     with open(dst_file, "w") as f:


### PR DESCRIPTION
This omits the Dockerfile table when no Dockerfile vulns are found.
