### PR TITLE
Updated workflows to v1.x - testing auto-updates

### DIFF
--- a/.github/workflows/build_scan_container.yml
+++ b/.github/workflows/build_scan_container.yml
@@ -47,7 +47,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Scan built image with Inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         id: inspector
         with:
           artifact_type: 'container'

--- a/.github/workflows/example_display_findings.yml
+++ b/.github/workflows/example_display_findings.yml
@@ -29,7 +29,7 @@ jobs:
       # modify this block to scan your intended artifact
       - name: Inspector Scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         with:
           # change artifact_type to either 'repository', 'container', 'binary', or 'archive'.
           # this example scans a container image

--- a/.github/workflows/example_vulnerability_threshold_exceeded.yml
+++ b/.github/workflows/example_vulnerability_threshold_exceeded.yml
@@ -48,7 +48,7 @@ jobs:
 
       # Inspector scan
       - name: Scan container with Inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.1.3
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         id: inspector
         with:
           artifact_type: 'container' # configure Inspector for scanning a container

--- a/.github/workflows/test_archive.yml
+++ b/.github/workflows/test_archive.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Test archive scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         with:
           artifact_type: 'archive'
           artifact_path: 'entrypoint/tests/test_data/artifacts/archives/testData.zip'

--- a/.github/workflows/test_binary.yml
+++ b/.github/workflows/test_binary.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Test binary scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         with:
           artifact_type: 'binary'
           artifact_path: 'entrypoint/tests/test_data/artifacts/binaries/inspector-sbomgen'

--- a/.github/workflows/test_containers.yml
+++ b/.github/workflows/test_containers.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Test container scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         with:
           artifact_type: 'container'
           artifact_path: 'ubuntu:14.04'

--- a/.github/workflows/test_dockerfile_vulns.yml
+++ b/.github/workflows/test_dockerfile_vulns.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Scan Dockerfiles
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         with:
           artifact_type: 'repository'
           artifact_path: './'

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -28,7 +28,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Test Amazon Inspector GitHub Actions plugin
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         with:
           artifact_type: 'container'
           artifact_path: 'alpine:latest'

--- a/.github/workflows/test_no_vulns.yml
+++ b/.github/workflows/test_no_vulns.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Test binary scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         with:
           artifact_type: 'binary'
           artifact_path: 'entrypoint/tests/test_data/artifacts/binaries/test_go_binary'

--- a/.github/workflows/test_reports_no_vulns.yml
+++ b/.github/workflows/test_reports_no_vulns.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Test container scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         with:
           artifact_type: 'container'
           artifact_path: 'alpine:latest'

--- a/.github/workflows/test_repository.yml
+++ b/.github/workflows/test_repository.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Test repository scan
         id: inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         with:
           artifact_type: 'repository'
           artifact_path: './'

--- a/.github/workflows/test_vuln_thresholds.yml
+++ b/.github/workflows/test_vuln_thresholds.yml
@@ -30,7 +30,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
 
       - name: Scan artifact with Inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@main
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         id: inspector
         with:
           artifact_type: 'archive'


### PR DESCRIPTION
This PR updates the example workflows to point to `v1`.

This tag will be used going forward so that users can automatically consume minor and point release updates.

Users can still opt into specific releases if they choose.


