### PR TITLE
Update README with @v1 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Perform the following steps to quickly add this action to your GitHub Actions pi
          # modify this block to scan your intended artifact
          - name: Inspector Scan
            id: inspector
-           uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.0.0
+           uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
            with:
              # change artifact_type to either 'repository', 'container', 'binary', or 'archive'.
              artifact_type: 'repository'
@@ -175,7 +175,7 @@ The below example shows how to enable action outputs in various locations and fo
 ```yaml
 - name: Scan container
   id: inspector
-  uses: aws/vulnerability-scan-github-action-for-amazon-inspector@v1.0.0
+  uses: aws/vulnerability-scan-github-action-for-amazon-inspector@v1
   with:
     artifact_type: 'container'
     artifact_path: 'ubuntu:14.04'
@@ -219,7 +219,7 @@ The example below shows how to set up vulnerability thresholds and fail the job 
 ```yaml
 - name: Invoke Amazon Inspector Scan
   id: inspector
-  uses: aws/vulnerability-scan-github-action-for-amazon-inspector@v1.0.0
+  uses: aws/vulnerability-scan-github-action-for-amazon-inspector@v1
   with:
     artifact_type: 'repository'
     artifact_path: './'
@@ -294,7 +294,7 @@ jobs:
           role-to-assume: "arn:aws:iam::<AWS_ACCOUNT_ID>:role/<IAM_ROLE_NAME>"
 
       - name: Scan built image with Inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1.0.0
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
         id: inspector
         with:
           artifact_type: 'container'


### PR DESCRIPTION
This PR updates the project README examples to utilize the @v1 tag for releases:

```
uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
```

This tag allows users to automatically consume minor and hotfix releases if they choose.

Users can still select specific versions if they wish.