### PR TITLE
Extend vulnerability severity providers

### DIFF
--- a/entrypoint/entrypoint/pkg_vuln.py
+++ b/entrypoint/entrypoint/pkg_vuln.py
@@ -15,7 +15,7 @@ NULL_STR = "null"
 class CvssSourceProvider:
     NVD = "NVD"
     MITRE = "MITRE"
-    GHSA = "GHSA"
+    GITHUB = "GITHUB"
     GITLAB = "GITLAB"
     REDHAT_CVE = "REDHAT_CVE"
     UBUNTU_CVE = "UBUNTU_CVE"
@@ -36,7 +36,7 @@ def get_rating_providers():
     # else in the order listed.
     providers = [CvssSourceProvider.NVD,
                  CvssSourceProvider.MITRE,
-                 CvssSourceProvider.GHSA,
+                 CvssSourceProvider.GITHUB,
                  CvssSourceProvider.GITLAB,
                  CvssSourceProvider.AMAZON_INSPECTOR
                  ]

--- a/entrypoint/entrypoint/pkg_vuln.py
+++ b/entrypoint/entrypoint/pkg_vuln.py
@@ -15,8 +15,8 @@ NULL_STR = "null"
 class CvssSourceProvider:
     NVD = "NVD"
     MITRE = "MITRE"
-    #GHSA = "GHSA"
-    #GITLAB = "GITLAB"
+    GHSA = "GHSA"
+    GITLAB = "GITLAB"
     AMAZON_INSPECTOR = "AMAZON_INSPECTOR"
     DEFAULT_PROVIDER = NVD
 
@@ -24,8 +24,8 @@ def get_rating_providers():
     # vuln severity is obtained in this order
     providers = [CvssSourceProvider.NVD,
                  CvssSourceProvider.MITRE,
-                 #CvssSourceProvider.GHSA,
-                 #CvssSourceProvider.GITLAB,
+                 CvssSourceProvider.GHSA,
+                 CvssSourceProvider.GITLAB,
                  CvssSourceProvider.AMAZON_INSPECTOR
                  ]
     return providers

--- a/entrypoint/entrypoint/pkg_vuln.py
+++ b/entrypoint/entrypoint/pkg_vuln.py
@@ -17,11 +17,23 @@ class CvssSourceProvider:
     MITRE = "MITRE"
     GHSA = "GHSA"
     GITLAB = "GITLAB"
+    REDHAT_CVE = "REDHAT_CVE"
+    UBUNTU_CVE = "UBUNTU_CVE"
     AMAZON_INSPECTOR = "AMAZON_INSPECTOR"
     DEFAULT_PROVIDER = NVD
 
 def get_rating_providers():
-    # vuln severity is obtained in this order
+    """
+    get_rating_providers returns a list of vulnerability
+    severity providers. The action uses this information
+    to determine which vuln severity to render when
+    multiple severity values are present from different
+    vendors. See the function definition to view the
+    order in which severity providers are preferred.
+    """
+
+    # NVD is most preferred, followed by everything
+    # else in the order listed.
     providers = [CvssSourceProvider.NVD,
                  CvssSourceProvider.MITRE,
                  CvssSourceProvider.GHSA,

--- a/entrypoint/entrypoint/pkg_vuln.py
+++ b/entrypoint/entrypoint/pkg_vuln.py
@@ -15,10 +15,20 @@ NULL_STR = "null"
 class CvssSourceProvider:
     NVD = "NVD"
     MITRE = "MITRE"
+    #GHSA = "GHSA"
+    #GITLAB = "GITLAB"
     AMAZON_INSPECTOR = "AMAZON_INSPECTOR"
-
     DEFAULT_PROVIDER = NVD
 
+def get_rating_providers():
+    # vuln severity is obtained in this order
+    providers = [CvssSourceProvider.NVD,
+                 CvssSourceProvider.MITRE,
+                 #CvssSourceProvider.GHSA,
+                 #CvssSourceProvider.GITLAB,
+                 CvssSourceProvider.AMAZON_INSPECTOR
+                 ]
+    return providers
 
 class CvssSeverity:
     UNTRIAGED = "untriaged"
@@ -255,7 +265,7 @@ def get_cwes(v) -> str:
 
 
 def get_cvss_rating(ratings, vulnerability) -> CvssRating:
-    rating_provider_priority = [CvssSourceProvider.NVD, CvssSourceProvider.MITRE, CvssSourceProvider.AMAZON_INSPECTOR]
+    rating_provider_priority = get_rating_providers()
     for provider in rating_provider_priority:
         for rating in ratings:
             if rating["source"]["name"] != provider:


### PR DESCRIPTION
Before this change, this action would only render vulnerability severity from one of three providers:
1. NVD
2. MITRE
3. AMAZON_INSPECTOR

This resulted in vulnerability count inconsistencies between Inspector ScanSbom raw json, and the summarized markdown report (see issue #89 ).

This PR adds additional vulnerability severity providers (shown in bold), which should resolve the vuln count discrepancies seen in #89:

1. NVD
2. MITRE
3. **GitHub Security Advisories**
4. **Redhat CVE**
5. **Ubuntu CVE**
6. AMAZON_INSPECTOR